### PR TITLE
Add playsinline attribute to prevent videos playing automatically in full-screen in mobile Safari

### DIFF
--- a/src/components/BackgroundVideo.astro
+++ b/src/components/BackgroundVideo.astro
@@ -13,7 +13,7 @@ const { isRounded } = Astro.props
   --borderRadius: ${isRounded ? '2rem' : '0'};
 `}
 >
-  <video loop muted autoplay data-persist="true" class="playlist-background">
+  <video loop muted autoplay playsinline data-persist="true" class="playlist-background">
     <source src="/purple-bg-video.mp4" type="video/mp4" />
   </video>
 </div>

--- a/src/components/CardMedia.astro
+++ b/src/components/CardMedia.astro
@@ -24,7 +24,7 @@ const { title, backgroundColor, media } = Astro.props
       <img src={media.url} alt={title} class="playlist-image" />
     ) : (
       <div data-persist-container="true">
-        <video loop muted autoplay class="playlist-image" data-persist="true">
+        <video loop muted autoplay playsinline class="playlist-image" data-persist="true">
           <source src={media.url} type="video/mp4" />
         </video>
       </div>

--- a/src/components/PlaylistMedia.astro
+++ b/src/components/PlaylistMedia.astro
@@ -18,7 +18,7 @@ const { title, media } = Astro.props
       <img src={media.url} alt={title} class="playlist-image" />
     ) : (
       <div data-persist-container="true">
-        <video loop muted autoplay class="playlist-image" data-persist="true">
+        <video loop muted autoplay playsinline class="playlist-image" data-persist="true">
           <source src={media.url} type="video/mp4" />
         </video>
       </div>


### PR DESCRIPTION
On mobile Safari, videos with the autoplay attribute will begin playing automatically in fullscreen without user interaction.

This PR adds the `playsinline` attribute to prevent that behavior

Read more: https://jahir.dev/blog/autoplay-videos-ux