### PR TITLE
Play nice with narrow-width devices

### DIFF
--- a/src/components/CardMedia.astro
+++ b/src/components/CardMedia.astro
@@ -71,5 +71,7 @@ const { title, backgroundColor, media } = Astro.props
   .card-media img {
     display: block;
     max-height: 360px;
+    max-width: 100vw;
+    object-fit: cover;
   }
 </style>

--- a/src/components/PlaylistMedia.astro
+++ b/src/components/PlaylistMedia.astro
@@ -35,6 +35,7 @@ const { title, media } = Astro.props
     justify-content: center;
     margin-top: 20px;
     width: 100%;
+    overflow-x: clip;
   }
 
   .playlist-media .card-media-overlay {


### PR DESCRIPTION
On narrow-width devices you get a horizontal scrollbar because the images can become too wide. You can emulate this in Chrome on Desktop using DevTools by setting the device to an iPhone SE for example.

The additions in this PR prevent those images from becoming wider than the viewport width.